### PR TITLE
Fix: drop enum not a function

### DIFF
--- a/src/database/migrations/20210905150614-createTable-Conteudo.js
+++ b/src/database/migrations/20210905150614-createTable-Conteudo.js
@@ -41,7 +41,7 @@ module.exports = {
   down: async (queryInterface) => {
     await queryInterface.dropTable("Conteudo");
     try {
-      await queryInterface.sequelize.dropEnum("enum_Conteudo_status");
+      await queryInterface.dropEnum("enum_Conteudo_status");
     } catch (e) {
       console.log(e);
     }


### PR DESCRIPTION
Co-authored-by: Carlos Rafael  <CarlosZoft@users.noreply.github.com>
Co-authored-by: ingridSCarvalho <ingridSCarvalho@users.noreply.github.com>

## Description 

arrumei um erro do drop enun não ser uma function

## Solve (Issues)

drop enum not a function
